### PR TITLE
feat: getActiveSection 유틸 구현 + 테스트

### DIFF
--- a/src/utils/__tests__/scroll.test.ts
+++ b/src/utils/__tests__/scroll.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from 'vitest'
+import { getActiveSection } from '../scroll'
+
+describe('getActiveSection', () => {
+  const sections = [
+    { id: 'hero',     top: 0,    height: 800 },
+    { id: 'skills',   top: 800,  height: 600 },
+    { id: 'projects', top: 1400, height: 700 },
+    { id: 'contact',  top: 2100, height: 400 },
+  ]
+
+  test('빈 섹션 배열이면 null 반환', () => {
+    expect(getActiveSection(0, [])).toBe(null)
+  })
+
+  test('scrollY 0 → 첫 번째 섹션', () => {
+    expect(getActiveSection(0, sections)).toBe('hero')
+  })
+
+  test('scrollY가 두 번째 섹션 진입 후 → skills', () => {
+    expect(getActiveSection(860, sections, 60)).toBe('skills')
+  })
+
+  test('scrollY가 음수 → null', () => {
+    expect(getActiveSection(-10, sections)).toBe(null)
+  })
+
+  test('scrollY가 마지막 섹션 → contact', () => {
+    expect(getActiveSection(2200, sections, 60)).toBe('contact')
+  })
+
+  test('섹션이 1개뿐 → 항상 그 섹션 id', () => {
+    expect(getActiveSection(500, [{ id: 'hero', top: 0, height: 800 }])).toBe('hero')
+  })
+})

--- a/src/utils/scroll.ts
+++ b/src/utils/scroll.ts
@@ -1,0 +1,29 @@
+export interface SectionRect {
+  id: string
+  top: number
+  height: number
+}
+
+/**
+ * 현재 스크롤 위치 기준으로 활성화된 섹션 ID 반환 (Nav 하이라이트용)
+ * @param scrollY   현재 window.scrollY
+ * @param sections  섹션 목록 (top, height 기준)
+ * @param offset    헤더 높이 등 보정값 (기본 60)
+ */
+export function getActiveSection(
+  scrollY: number,
+  sections: SectionRect[],
+  offset = 60,
+): string | null {
+  if (sections.length === 0 || scrollY < 0) return null
+
+  const adjustedY = scrollY + offset
+
+  let active: string | null = null
+  for (const section of sections) {
+    if (adjustedY >= section.top) {
+      active = section.id
+    }
+  }
+  return active
+}


### PR DESCRIPTION
## 변경사항
- `src/utils/scroll.ts` — `getActiveSection` 구현
- `src/utils/__tests__/scroll.test.ts` — 테스트 6개 전체 통과 ✅

## 테스트 결과
```
✓ 빈 섹션 배열이면 null 반환
✓ scrollY 0 → 첫 번째 섹션
✓ scrollY가 두 번째 섹션 진입 후 → skills
✓ scrollY가 음수 → null
✓ scrollY가 마지막 섹션 → contact
✓ 섹션이 1개뿐 → 항상 그 섹션 id
```

Closes #3