### PR TITLE
feat: truncateText 유틸 구현 + 테스트

### DIFF
--- a/src/utils/__tests__/string.test.ts
+++ b/src/utils/__tests__/string.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from 'vitest'
+import { truncateText } from '../string'
+
+describe('truncateText', () => {
+  test('길이 이하이면 그대로 반환', () => {
+    expect(truncateText('Hello', 10)).toBe('Hello')
+  })
+
+  test('길이 초과 시 말줄임표 추가', () => {
+    expect(truncateText('Hello World', 5)).toBe('Hello…')
+  })
+
+  test('빈 문자열', () => {
+    expect(truncateText('', 10)).toBe('')
+  })
+
+  test('정확히 maxLength와 같은 길이 → 원본 반환', () => {
+    expect(truncateText('Hello', 5)).toBe('Hello')
+  })
+
+  test('maxLength 0 → 말줄임표만', () => {
+    expect(truncateText('Hello', 0)).toBe('…')
+  })
+
+  test('maxLength 음수 → 빈 문자열', () => {
+    expect(truncateText('Hello', -1)).toBe('')
+  })
+})

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,10 @@
+/**
+ * 텍스트를 지정 길이로 자르고 말줄임표 추가 (프로젝트 설명 등)
+ * @param text       원본 텍스트
+ * @param maxLength  최대 길이
+ */
+export function truncateText(text: string, maxLength: number): string {
+  if (maxLength < 0) return ''
+  if (text.length <= maxLength) return text
+  return text.slice(0, maxLength) + '…'
+}


### PR DESCRIPTION
## 변경사항
- `src/utils/string.ts` — `truncateText` 구현
- `src/utils/__tests__/string.test.ts` — 테스트 6개 전체 통과 ✅

## 테스트 결과
```
✓ 길이 이하이면 그대로 반환
✓ 길이 초과 시 말줄임표 추가
✓ 빈 문자열
✓ 정확히 maxLength와 같은 길이 → 원본 반환
✓ maxLength 0 → 말줄임표만
✓ maxLength 음수 → 빈 문자열
```

Closes #4