### PR TITLE
feat: groupBy 유틸 구현 + 테스트

### DIFF
--- a/src/utils/__tests__/array.test.ts
+++ b/src/utils/__tests__/array.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from 'vitest'
+import { groupBy } from '../array'
+
+describe('groupBy', () => {
+  test('카테고리별 그룹핑', () => {
+    const items = [
+      { name: 'React', category: 'Frontend' },
+      { name: 'Git',   category: 'Tools' },
+      { name: 'Vite',  category: 'Frontend' },
+    ]
+    const result = groupBy(items, (i) => i.category)
+    expect(result['Frontend']).toHaveLength(2)
+    expect(result['Tools']).toHaveLength(1)
+  })
+
+  test('빈 배열 → 빈 객체', () => {
+    expect(groupBy([], (i) => String(i))).toEqual({})
+  })
+
+  test('모든 항목이 같은 키 → 키 1개짜리 객체', () => {
+    const items = [{ v: 1 }, { v: 2 }, { v: 3 }]
+    const result = groupBy(items, () => 'same')
+    expect(Object.keys(result)).toHaveLength(1)
+    expect(result['same']).toHaveLength(3)
+  })
+
+  test('keyFn이 빈 문자열 반환 → "" 키로 그룹핑', () => {
+    const items = [{ v: 1 }, { v: 2 }]
+    const result = groupBy(items, () => '')
+    expect(result['']).toHaveLength(2)
+  })
+})

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,16 @@
+/**
+ * 배열을 키 기준으로 그룹핑 (스킬 카테고리 그룹핑 등)
+ * @param items  그룹핑할 배열
+ * @param keyFn  각 아이템의 그룹 키를 반환하는 함수
+ */
+export function groupBy<T>(
+  items: T[],
+  keyFn: (item: T) => string,
+): Record<string, T[]> {
+  return items.reduce<Record<string, T[]>>((acc, item) => {
+    const key = keyFn(item)
+    if (!acc[key]) acc[key] = []
+    acc[key].push(item)
+    return acc
+  }, {})
+}


### PR DESCRIPTION
## 변경사항
- `src/utils/array.ts` — `groupBy` 구현
- `src/utils/__tests__/array.test.ts` — 테스트 4개 전체 통과 ✅

## 테스트 결과
```
✓ 카테고리별 그룹핑
✓ 빈 배열 → 빈 객체
✓ 모든 항목이 같은 키 → 키 1개짜리 객체
✓ keyFn이 빈 문자열 반환 → "" 키로 그룹핑
```

Closes #5