### PR TITLE
feat: Nav 스크롤 스파이 - 현재 섹션 활성화 표시

### DIFF
--- a/src/components/Header/header.css
+++ b/src/components/Header/header.css
@@ -73,9 +73,14 @@
   transition: color 0.2s ease;
 }
 
-.header__nav-link:hover {
+.header__nav-link:hover,
+.header__nav-link--active {
   background-color: var(--color-surface);
   color: var(--color-primary);
+}
+
+.header__nav-link--active {
+  font-weight: 600;
 }
 
 .header__hamburger {
@@ -138,9 +143,14 @@
     font-size: 15px;
   }
 
-  .header__nav-link:hover {
+  .header__nav-link:hover,
+  .header__nav-link--active {
     background: none;
     color: var(--color-primary);
+  }
+
+  .header__nav-link--active {
+    font-weight: 600;
   }
 
   .header__hamburger {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useScrollSpy } from '../../hooks/useScrollSpy';
 import './header.css';
 
 const NAV_ITEMS = [
@@ -11,6 +12,7 @@ const NAV_ITEMS = [
 function Header() {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const activeId = useScrollSpy();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -69,7 +71,11 @@ function Header() {
           <ul className="header__nav-list">
             {NAV_ITEMS.map(({ label, href }) => (
               <li key={href} className="header__nav-item">
-                <a href={href} className="header__nav-link" onClick={closeMenu}>
+                <a
+                  href={href}
+                  className={`header__nav-link${activeId === href.slice(1) ? ' header__nav-link--active' : ''}`}
+                  onClick={closeMenu}
+                >
                   {label}
                 </a>
               </li>

--- a/src/hooks/useScrollSpy.ts
+++ b/src/hooks/useScrollSpy.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect } from 'react'
+import { getActiveSection } from '../utils/scroll'
+
+const SECTION_IDS = ['hero', 'skills', 'projects', 'contact']
+const HEADER_OFFSET = 80
+
+/**
+ * 현재 스크롤 위치 기준으로 활성 섹션 ID를 반환하는 훅
+ */
+export function useScrollSpy(): string | null {
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  useEffect(() => {
+    const getSections = () =>
+      SECTION_IDS.map((id) => {
+        const el = document.getElementById(id)
+        return el
+          ? { id, top: el.offsetTop, height: el.offsetHeight }
+          : null
+      }).filter(Boolean) as { id: string; top: number; height: number }[]
+
+    const handleScroll = () => {
+      const sections = getSections()
+      setActiveId(getActiveSection(window.scrollY, sections, HEADER_OFFSET))
+    }
+
+    // 초기값 설정
+    handleScroll()
+
+    window.addEventListener('scroll', handleScroll, { passive: true })
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  return activeId
+}


### PR DESCRIPTION
## 변경사항
- `src/hooks/useScrollSpy.ts` — `getActiveSection` 유틸 기반 스크롤 스파이 훅
- `Header/index.tsx` — `useScrollSpy` 연결, active 클래스 적용
- `Header/header.css` — `.header__nav-link--active` 스타일 (모바일/데스크탑)

## 동작
스크롤 위치에 따라 현재 섹션의 Nav 링크가 자동 하이라이트돼요.

Closes #6