### PR TITLE
feat: depth 상태 관리 + 휠/스와이프 이동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,11 @@
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
         "@react-three/postprocessing": "^3.0.4",
+        "gsap": "^3.14.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "three": "^0.183.2"
+        "three": "^0.183.2",
+        "zustand": "^5.0.12"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -3744,6 +3746,12 @@
       "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
       "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
       "license": "MIT"
+    },
+    "node_modules/gsap": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.14.2.tgz",
+      "integrity": "sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA==",
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/has-flag": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
     "@react-three/postprocessing": "^3.0.4",
+    "gsap": "^3.14.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "three": "^0.183.2"
+    "three": "^0.183.2",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/canvas/OceanCanvas.tsx
+++ b/src/canvas/OceanCanvas.tsx
@@ -1,36 +1,26 @@
 import { Canvas } from '@react-three/fiber'
 import { Suspense } from 'react'
 import { OceanScene } from './OceanScene'
+import { useDepthStore } from '../store/depthStore'
+import { useDepthNavigation } from '../hooks/useDepthNavigation'
 import styled from '@emotion/styled'
-import { css } from '@emotion/react'
 
-const fullscreenStyle = css`
+const CanvasWrapper = styled.div`
   position: fixed;
   inset: 0;
   width: 100%;
   height: 100%;
 `
 
-const CanvasWrapper = styled.div`
-  ${fullscreenStyle}
-`
-
-const LoadingScreen = styled.div`
-  ${fullscreenStyle}
-  background: hsl(220, 80%, 10%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: rgba(125, 211, 252, 0.6);
-  font-family: sans-serif;
-  font-size: 14px;
-  letter-spacing: 0.1em;
-`
-
-// 모바일 디바이스 감지 (antialias 성능 최적화용)
+// 모바일 감지 — antialias 성능 최적화
 const isMobile = /mobile|android|iphone|ipad/i.test(navigator.userAgent)
 
 export function OceanCanvas() {
+  const depth = useDepthStore((s) => s.depth)
+
+  // 휠/스와이프 이동 활성화
+  useDepthNavigation()
+
   return (
     <CanvasWrapper>
       <Canvas
@@ -42,12 +32,9 @@ export function OceanCanvas() {
         }}
       >
         <Suspense fallback={null}>
-          <OceanScene />
+          <OceanScene depth={depth} />
         </Suspense>
       </Canvas>
-      {/* Canvas 로딩 전 fallback — Suspense가 해소되면 사라짐 */}
     </CanvasWrapper>
   )
 }
-
-export { LoadingScreen }

--- a/src/hooks/useDepthNavigation.ts
+++ b/src/hooks/useDepthNavigation.ts
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from 'react'
+import { useDepthStore } from '../store/depthStore'
+
+const WHEEL_THRESHOLD = 50   // px — 이 이상 스크롤해야 이동
+const TOUCH_THRESHOLD = 40   // px — 스와이프 민감도
+const COOLDOWN_MS = 1200     // 연속 이동 방지 (애니메이션 시간과 맞춤)
+
+/**
+ * 마우스 휠 + 터치 스와이프로 depth 이동
+ */
+export function useDepthNavigation(enabled = true) {
+  const { goDeeper, goShallower, isAnimating } = useDepthStore()
+  const lastMoveTime = useRef(0)
+  const touchStartY = useRef(0)
+
+  useEffect(() => {
+    if (!enabled) return
+
+    const canMove = () => {
+      const now = Date.now()
+      if (isAnimating || now - lastMoveTime.current < COOLDOWN_MS) return false
+      lastMoveTime.current = now
+      return true
+    }
+
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault()
+      if (!canMove()) return
+
+      if (e.deltaY > WHEEL_THRESHOLD) {
+        // 아래로 스크롤 → 더 얕게 (수면 방향)
+        goShallower()
+      } else if (e.deltaY < -WHEEL_THRESHOLD) {
+        // 위로 스크롤 → 더 깊게 (심해 방향)
+        goDeeper()
+      }
+    }
+
+    const handleTouchStart = (e: TouchEvent) => {
+      touchStartY.current = e.touches[0].clientY
+    }
+
+    const handleTouchEnd = (e: TouchEvent) => {
+      const deltaY = touchStartY.current - e.changedTouches[0].clientY
+      if (Math.abs(deltaY) < TOUCH_THRESHOLD || !canMove()) return
+
+      if (deltaY > 0) {
+        goShallower() // 위로 스와이프 → 수면
+      } else {
+        goDeeper()    // 아래로 스와이프 → 심해
+      }
+    }
+
+    window.addEventListener('wheel', handleWheel, { passive: false })
+    window.addEventListener('touchstart', handleTouchStart, { passive: true })
+    window.addEventListener('touchend', handleTouchEnd, { passive: true })
+
+    return () => {
+      window.removeEventListener('wheel', handleWheel)
+      window.removeEventListener('touchstart', handleTouchStart)
+      window.removeEventListener('touchend', handleTouchEnd)
+    }
+  }, [enabled, isAnimating, goDeeper, goShallower])
+}

--- a/src/store/depthStore.ts
+++ b/src/store/depthStore.ts
@@ -1,0 +1,74 @@
+import { create } from 'zustand'
+import gsap from 'gsap'
+
+// depth: 0.0 = 수면 (밝음), 1.0 = 심해 (어두움)
+// 섹션별 depth 앵커
+export const SECTION_DEPTHS: Record<string, number> = {
+  intro:      1.0,  // 심해 — 진입점
+  work:       0.75, // 깊음 — 최신 경력
+  projects:   0.5,  // 중간 — 프로젝트
+  skills:     0.3,  // 얕음 — 스킬 + 스토리
+  activities: 0.1,  // 거의 수면 — 대외활동
+  contact:    0.0,  // 수면 — 연락처
+}
+
+const SECTION_ORDER = Object.keys(SECTION_DEPTHS)
+const STEP = 1 / (SECTION_ORDER.length - 1) // 섹션 간 이동 간격
+const ANIM_DURATION = 1.2 // seconds
+const ANIM_EASE = 'power2.inOut'
+
+interface DepthState {
+  depth: number           // 현재 깊이 (0~1)
+  targetDepth: number     // 목표 깊이
+  activeSection: string   // 현재 활성 섹션
+  isAnimating: boolean
+
+  setDepth: (depth: number) => void
+  goToSection: (section: string) => void
+  goDeeper: () => void    // 더 깊이 (심해 방향)
+  goShallower: () => void // 더 얕게 (수면 방향)
+}
+
+// GSAP tween 참조 (중복 실행 방지)
+let currentTween: gsap.core.Tween | null = null
+
+export const useDepthStore = create<DepthState>((set, get) => ({
+  depth: SECTION_DEPTHS.intro,
+  targetDepth: SECTION_DEPTHS.intro,
+  activeSection: 'intro',
+  isAnimating: false,
+
+  setDepth: (depth: number) => {
+    set({ depth: Math.max(0, Math.min(1, depth)) })
+  },
+
+  goToSection: (section: string) => {
+    const target = SECTION_DEPTHS[section]
+    if (target === undefined) return
+
+    const proxy = { value: get().depth }
+    currentTween?.kill()
+
+    set({ targetDepth: target, activeSection: section, isAnimating: true })
+
+    currentTween = gsap.to(proxy, {
+      value: target,
+      duration: ANIM_DURATION,
+      ease: ANIM_EASE,
+      onUpdate: () => set({ depth: proxy.value }),
+      onComplete: () => set({ isAnimating: false }),
+    })
+  },
+
+  goDeeper: () => {
+    const currentIndex = Math.round(get().depth / STEP)
+    const nextIndex = Math.min(currentIndex + 1, SECTION_ORDER.length - 1)
+    get().goToSection(SECTION_ORDER[nextIndex])
+  },
+
+  goShallower: () => {
+    const currentIndex = Math.round(get().depth / STEP)
+    const prevIndex = Math.max(currentIndex - 1, 0)
+    get().goToSection(SECTION_ORDER[prevIndex])
+  },
+}))


### PR DESCRIPTION
## 변경사항
- `zustand`, `gsap` 설치
- `src/store/depthStore.ts` — Zustand 기반 depth 상태, GSAP smooth 보간
- `src/hooks/useDepthNavigation.ts` — 휠/스와이프 이벤트 → depth 이동
- `OceanCanvas` — depth 구독 + 네비게이션 훅 연결

## 동작
- 마우스 휠 아래 → 수면 방향, 위 → 심해 방향
- 터치 스와이프 동일하게 작동
- GSAP 1.2s smooth 이동
- 연속 입력 방지 (쿨다운)

Closes #28